### PR TITLE
GraphQL schema to SOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IDEs
+.idea/
+
+# Python
+.venv/

--- a/README.org
+++ b/README.org
@@ -43,9 +43,25 @@ Overview (uncheck "Show leaf fields"):
 
 [[bsdd-graphql-voyager-overview.png]]
 
-
-
 [[bsdd-graphql-voyager-Classification-ClassificationProperty.png]]
+
+** GraphQL Conversion to SOML Schema
+
+Major goal of this project is to improve the bSDD GraphQL API.
+To achieve this, the existing GraphQL schema will be converted to a [[https://platform.ontotext.com/semantic-objects/soml/index.html][SOML schema]]
+which then will be manually improved and finally used to generate a better GraphQL API with the help of [[https://platform.ontotext.com/semantic-objects/][Ontotext Platform]].
+
+The repository contains a Python utility script [[./graphql2soml.py][graphql2soml.py]] that can generate a
+[[https://platform.ontotext.com/semantic-objects/soml/index.html][SOML schema]] from given GraphQL endpoint.
+
+Executing this script produces two files in the repository:
+
+- [[./bsdd-graphql-schema-orig.json][bsdd-graphql-schema-orig.json]] - JSON response of the GraphQL introspection
+- [[./bsdd-graphql-soml-orig.yaml][bsdd-graphql-soml-orig.yaml]] - SOML schema produced from the introspection
+
+The generated SOML schema is valid and can be used immediately. However, there are issues inherited from the GraphQL schema which are described later.
+The purpose of the generated SOML schema is to serve as a starting point (instead of starting from scratch) for resolving the issues and improving the schema.
+Once this is done, the resulting schema will be saved in [[./bsdd-graphql-soml-refact.yaml][bsdd-graphql-soml-refact.yaml]].
 
 ** Original vs Refactored Files
 bsdd-graphql-voyager-orig.html

--- a/bsdd-graphql-schema-orig.json
+++ b/bsdd-graphql-schema-orig.json
@@ -1,0 +1,3774 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "RootQuery"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server supports subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given __Type is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use 'locations'."
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use 'locations'."
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use 'locations'."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RootQuery",
+          "description": null,
+          "fields": [
+            {
+              "name": "countries",
+              "description": "Get a list of all countries",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Country",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "classification",
+              "description": "Get a classification",
+              "args": [
+                {
+                  "name": "namespaceUri",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "languageCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeChilds",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Classification",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "domain",
+              "description": "Search for classifications within a domain",
+              "args": [
+                {
+                  "name": "namespaceUri",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Domain",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "domains",
+              "description": "Get a list of all domains",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Domain",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "languages",
+              "description": "Get a list of all languages",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Language",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "property",
+              "description": "Get a property",
+              "args": [
+                {
+                  "name": "namespaceUri",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "languageCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Property",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "referenceDocuments",
+              "description": "Get a list of all reference documents",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ReferenceDocument",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": "Get a list of all units",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Unit",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Country",
+          "description": "",
+          "fields": [
+            {
+              "name": "code",
+              "description": "Unique identification of the country",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Country name",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Classification",
+          "description": "A classification can be any (abstract) object (e.g. \u201cIfcWall\u201d), abstract concept (e.g. \u201cCosting\u201d) or process (e.g. \u201cInstallation\u201d). Classifications can be organized in a tree like structure. For example: \u201cIfcCurtainWall\u201d is a more specific classification of \u201cIfcWall\u201d. We use the term \u201cparent\u201d to identify this relation: the parent of \u201cIfcCurtainWall\u201d is \u201cIfcWall\u201d.",
+          "fields": [
+            {
+              "name": "classificationType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "ClassificationType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relatedIfcEntityNames",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "synonyms",
+              "description": "List of synonyms for the classification",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "referenceCode",
+              "description": "Optional code for domain specific use",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ClassificationProperty",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "property",
+              "description": "Select a property",
+              "args": [
+                {
+                  "name": "namespaceUri",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ClassificationProperty",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ClassificationRelation",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "childs",
+              "description": "Include list of childs, with simple properties only. Only available when using the classification function with option 'includeChilds = true'.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Classification",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activationDateUtc",
+              "description": "Date of activation",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "Code used originally by the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creatorLanguageCode",
+              "description": "Language code of the creator",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countriesOfUse",
+              "description": "List of countries where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countryOfOrigin",
+              "description": "Country of origin",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deActivationDateUtc",
+              "description": "Date of deactivation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "definition",
+              "description": "Definition",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationExplanation",
+              "description": "Explanation of the deprecation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "documentReference",
+              "description": "Reference to a(n official) document",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Plain name of the classification",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "namespaceUri",
+              "description": "Unique identification of the classification",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacedObjectCodes",
+              "description": "List of codes of the replaced items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacingObjectCodes",
+              "description": "List of codes of the replacing items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionDateUtc",
+              "description": "Date of the revision",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionNumber",
+              "description": "Revision number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Status, can be: Preview, Active or Inactive",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subdivisionsOfUse",
+              "description": "List of subdivisions (e.g. states) where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uid",
+              "description": "Alternative unique global identification",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionDateUtc",
+              "description": "Date of the version",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionNumber",
+              "description": "Version number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visualRepresentationUri",
+              "description": "URI of a visual representation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ClassificationType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CLASS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPOSED_PROPERTY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DOMAIN",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GROUP_OF_PROPERTIES",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "REFERENCE_DOCUMENT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ALTERNATIVE_USE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MATERIAL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ClassificationProperty",
+          "description": "Attributes of a property of a classification. A property can be part of many classifications but the restrictions for the property can differ per classification",
+          "fields": [
+            {
+              "name": "allowedValues",
+              "description": "List of allowed values",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ClassificationPropertyValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataType",
+              "description": "Format for expressing the value of the property: Boolean, Character, Date, Enumeration, Integer, Real, String, Time",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "Plain language description of the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimension",
+              "description": "Dimension of the physical quantity in format 'L M T I \u0398 N J', for example '-2 1 0 0 0 0 0'.\r\n                                                  With\r\n                                                    L   Length\r\n                                                    M   Mass\r\n                                                    T   Time\r\n                                                    I   Electric current\r\n                                                    \u0398   Thermodynamic Temperature\r\n                                                    N   Amount of substance\r\n                                                    J   Luminous intensity\r\n",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionLength",
+              "description": "The Length value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionMass",
+              "description": "The Mass value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionTime",
+              "description": "The Time value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionElectricCurrent",
+              "description": "The Electric Current value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionThermodynamicTemperature",
+              "description": "The Thermodynamic Temperature value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionAmountOfSubstance",
+              "description": "The Amount Of Substance value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionLuminousIntensity",
+              "description": "The Luminous Intensity value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dynamicParameterPropertyCodes",
+              "description": "List of codes of the properties which are parameters of the function for a dynamic property. Only applicable for dynamic properties (IsDynamic)",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "example",
+              "description": "Illustrate possible use or values of the Property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDynamic",
+              "description": "True if the value of this property is dependent on other properties (as provided in DynamicParameterPropertyCodes)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRequired",
+              "description": "Indicates if the property is required to be filled for this classification",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isWritable",
+              "description": "Indicates if the property value can be changed",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxExclusive",
+              "description": "Maximum value of the property, exclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxInclusive",
+              "description": "Maximum value of the property, inclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "methodOfMeasurement",
+              "description": "Description of the method of measurement",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minExclusive",
+              "description": "Minimum value of the property, exclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minInclusive",
+              "description": "Minimum value of the property, inclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pattern",
+              "description": "An XML Schema Regular expression for the property value. See for explanation: https://www.regular-expressions.info/xml.html.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "physicalQuantity",
+              "description": "The quantity in plain text",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleValues",
+              "description": "DEPRECATED - please use allowedValues instead",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ClassificationPropertyValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "predefinedValue",
+              "description": "Predefined value for the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "propertySet",
+              "description": "Name of the property set",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "propertyValueKind",
+              "description": "Indicates kind of value: Single, Range (2 values expected), List (multiple values expected), Complex (use in combination with ConnectedProperties), ComplexList",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "PropertyValueKind",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "symbol",
+              "description": "Symbol of the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "textFormat",
+              "description": "The text type, e.g. UTF-8",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": "List of units",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activationDateUtc",
+              "description": "Date of activation",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "Code used originally by the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creatorLanguageCode",
+              "description": "Language code of the creator",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countriesOfUse",
+              "description": "List of countries where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countryOfOrigin",
+              "description": "Country of origin",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deActivationDateUtc",
+              "description": "Date of deactivation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "definition",
+              "description": "Definition",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationExplanation",
+              "description": "Explanation of the deprecation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "documentReference",
+              "description": "Reference to a(n official) document",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Plain name of the property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "namespaceUri",
+              "description": "Unique identification of the property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacedObjectCodes",
+              "description": "List of codes of the replaced items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacingObjectCodes",
+              "description": "List of codes of the replacing items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionDateUtc",
+              "description": "Date of the revision",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionNumber",
+              "description": "Revision number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Status, can be: Preview, Active or Inactive",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subdivisionsOfUse",
+              "description": "List of subdivisions (e.g. states) where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uid",
+              "description": "Alternative unique global identification",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionDateUtc",
+              "description": "Date of the version",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionNumber",
+              "description": "Version number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visualRepresentationUri",
+              "description": "URI of a visual representation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ClassificationPropertyValue",
+          "description": "Attributes of possible values of a property of a classification.",
+          "fields": [
+            {
+              "name": "namespaceUri",
+              "description": "Globally unique identification of the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "Code of the value",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "Description of the value",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sortNumber",
+              "description": "Sort number (if sorting of the values has been specified)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Decimal",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PropertyValueKind",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SINGLE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RANGE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPLEX",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMPLEX_LIST",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": "The `DateTime` scalar type represents a date and time. `DateTime` expects timestamps to be formatted in accordance with the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) standard.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ClassificationRelation",
+          "description": "Attributes of a relation of a classification with another classification, can be from a different domain.",
+          "fields": [
+            {
+              "name": "relatedClassificationName",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relatedClassificationUri",
+              "description": "The namespace uri of the related classification",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relationType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Domain",
+          "description": "Contains general information about the domain and the delivered data.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": "The version of the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "namespaceUri",
+              "description": "The unique identification of the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "releaseDate",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "license",
+              "description": "The type of license for using data of this domain",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "licenseUrl",
+              "description": "Url with more info about the license",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "copyrightNotice",
+              "description": "The domain copyright",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moreInfoUrl",
+              "description": "Url with more info about the domain",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastUpdatedUtc",
+              "description": "UTC date this domain was last updated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "languageCode",
+              "description": "The language the results will be returned in if no language specified or if specified language is not available",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "classificationSearch",
+              "description": "Search for classifications in the domain. Results are limited to max 5000 items.",
+              "args": [
+                {
+                  "name": "searchText",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "\"\""
+                },
+                {
+                  "name": "languageCode",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "\"\""
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Classification",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "classification",
+              "description": "Select a classification",
+              "args": [
+                {
+                  "name": "namespaceUri",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "languageCode",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "\"\""
+                },
+                {
+                  "name": "includeChilds",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Classification",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Language",
+          "description": "",
+          "fields": [
+            {
+              "name": "isocode",
+              "description": "Unique identification of the language",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Language name",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Property",
+          "description": null,
+          "fields": [
+            {
+              "name": "allowedValues",
+              "description": "List of allowed values",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PropertyValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "connectedPropertyCodes",
+              "description": "List of codes of connected properties",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dataType",
+              "description": "Format for expressing the value of the property: Boolean, Character, Date, Enumeration, Integer, Real, String, Time",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "Plain language description of the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimension",
+              "description": "Dimension of the physical quantity in format 'L M T I \u0398 N J', for example '-2 1 0 0 0 0 0'.\r\n                                                  With\r\n                                                    L   Length\r\n                                                    M   Mass\r\n                                                    T   Time\r\n                                                    I   Electric current\r\n                                                    \u0398   Thermodynamic Temperature\r\n                                                    N   Amount of substance\r\n                                                    J   Luminous intensity\r\n",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionLength",
+              "description": "The Length value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionMass",
+              "description": "The Mass value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionTime",
+              "description": "The Time value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionElectricCurrent",
+              "description": "The Electric current value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionThermodynamicTemperature",
+              "description": "The Thermodynamic temperature value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionAmountOfSubstance",
+              "description": "The Amount of substance value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dimensionLuminousIntensity",
+              "description": "The Luminous Intensity value of the dimension",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dynamicParameterPropertyCodes",
+              "description": "List of codes of the properties which are parameters of the function for a dynamic property. Only applicable for dynamic properties (IsDynamic)",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "example",
+              "description": "Illustrate possible use or values of the Property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDynamic",
+              "description": "True if the value of this property is dependent on other properties (as provided in DynamicParameterPropertyCodes)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxExclusive",
+              "description": "Maximum value of the property, exclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxInclusive",
+              "description": "Maximum value of the property, inclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "methodOfMeasurement",
+              "description": "Description of the method of measurement",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minExclusive",
+              "description": "Minimum value of the property, exclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minInclusive",
+              "description": "Minimum value of the property, inclusive",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Decimal",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pattern",
+              "description": "An XML Schema Regular expression for the property value. See for explanation: https://www.regular-expressions.info/xml.html.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "physicalQuantity",
+              "description": "The quantity in plain text",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "propertyValueKind",
+              "description": "Indicates kind of value: Single, Range (2 values expected), List (multiple values expected), Complex (use in combination with ConnectedProperties), ComplexList",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "PropertyValueKind",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleValues",
+              "description": "DEPRECATED - please use allowedValues",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PropertyValue",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relations",
+              "description": "List of related properties",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PropertyRelation",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "textFormat",
+              "description": "The text type, e.g. UTF-8",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": "List of units",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activationDateUtc",
+              "description": "Date of activation",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "Code used originally by the domain",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "creatorLanguageCode",
+              "description": "Language code of the creator",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countriesOfUse",
+              "description": "List of countries where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countryOfOrigin",
+              "description": "Country of origin",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deActivationDateUtc",
+              "description": "Date of deactivation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "definition",
+              "description": "Definition",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationExplanation",
+              "description": "Explanation of the deprecation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "documentReference",
+              "description": "Reference to a(n official) document",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Plain name of the property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "namespaceUri",
+              "description": "Unique identification of the property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacedObjectCodes",
+              "description": "List of codes of the replaced items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "replacingObjectCodes",
+              "description": "List of codes of the replacing items",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionDateUtc",
+              "description": "Date of the revision",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revisionNumber",
+              "description": "Revision number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Status, can be: Preview, Active or Inactive",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subdivisionsOfUse",
+              "description": "List of subdivisions (e.g. states) where used",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uid",
+              "description": "Alternative unique global identification",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionDateUtc",
+              "description": "Date of the version",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "versionNumber",
+              "description": "Version number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "visualRepresentationUri",
+              "description": "URI of a visual representation",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PropertyValue",
+          "description": "Attributes of possible values of a property.",
+          "fields": [
+            {
+              "name": "namespaceUri",
+              "description": "Globally unique identification of the property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": "Code of the value (unique within the property)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "Description of the value",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "The value (unique within the property)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sortNumber",
+              "description": "Sort number (if sorting of the values has been specified)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PropertyRelation",
+          "description": "Attributes of a relation of a property with another property, can be from a different domain.",
+          "fields": [
+            {
+              "name": "relatedPropertyName",
+              "description": "Name of the related property",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relatedPropertyUri",
+              "description": "The namespace uri of the related property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "relationType",
+              "description": "Type of the relation with the reference property",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ReferenceDocument",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "Unique identification of the reference document",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Reference document name",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "date",
+              "description": "Reference document date",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Unit",
+          "description": "",
+          "fields": [
+            {
+              "name": "code",
+              "description": "Unique identification of the unit",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "Unit name",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "symbol",
+              "description": "Unit symbol",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the 'if' argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the 'if' argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/bsdd-graphql-soml-orig.yaml
+++ b/bsdd-graphql-soml-orig.yaml
@@ -1,0 +1,649 @@
+id: /soml/bsdd
+label: null
+creator: null
+created: null
+updated: null
+versionInfo: null
+config: null
+types:
+  ClassificationType:
+    values:
+    - name: CLASS
+    - name: COMPOSED_PROPERTY
+    - name: DOMAIN
+    - name: GROUP_OF_PROPERTIES
+    - name: REFERENCE_DOCUMENT
+    - name: ALTERNATIVE_USE
+    - name: MATERIAL
+  PropertyValueKind:
+    values:
+    - name: SINGLE
+    - name: RANGE
+    - name: LIST
+    - name: COMPLEX
+    - name: COMPLEX_LIST
+prefixes:
+  bsdd: https://identifier.buildingsmart.org/def#
+specialPrefixes:
+  base_iri: https://identifier.buildingsmart.org/uri/
+  vocab_iri: https://identifier.buildingsmart.org/def#
+  vocab_prefix: bsdd
+properties: {}
+objects:
+  Country:
+    type: Country
+    label: Country
+    props:
+      code:
+        label: Unique identification of the country
+        min: 1
+        range: string
+      name:
+        label: Country name
+        min: 1
+        range: string
+  Classification:
+    type: Classification
+    label: "A classification can be any (abstract) object (e.g. \u201CIfcWall\u201D), abstract concept (e.g. \u201CCosting\u201D) or process (e.g. \u201CInstallation\u201D). Classifications can be organized in a tree like structure. For example: \u201CIfcCurtainWall\u201D is a more specific classification of \u201CIfcWall\u201D. We use the term \u201Cparent\u201D to identify this relation: the parent of \u201CIfcCurtainWall\u201D is \u201CIfcWall\u201D."
+    props:
+      classificationType:
+        label: classificationType
+        range: ClassificationType
+      relatedIfcEntityNames:
+        label: relatedIfcEntityNames
+        max: inf
+        range: string
+      synonyms:
+        label: List of synonyms for the classification
+        max: inf
+        range: string
+      referenceCode:
+        label: Optional code for domain specific use
+        range: string
+      properties:
+        label: properties
+        max: inf
+        range: ClassificationProperty
+      property:
+        label: Select a property
+        range: ClassificationProperty
+      relations:
+        label: relations
+        max: inf
+        range: ClassificationRelation
+      childs:
+        label: Include list of childs, with simple properties only. Only available when using the classification function with option 'includeChilds = true'.
+        max: inf
+        range: Classification
+      activationDateUtc:
+        label: Date of activation
+        min: 1
+        range: dateTime
+      code:
+        label: Code used originally by the domain
+        min: 1
+        range: string
+      creatorLanguageCode:
+        label: Language code of the creator
+        range: string
+      countriesOfUse:
+        label: List of countries where used
+        max: inf
+        range: string
+      countryOfOrigin:
+        label: Country of origin
+        range: string
+      deActivationDateUtc:
+        label: Date of deactivation
+        range: dateTime
+      definition:
+        label: Definition
+        range: string
+      deprecationExplanation:
+        label: Explanation of the deprecation
+        range: string
+      documentReference:
+        label: Reference to a(n official) document
+        range: string
+      name:
+        label: Plain name of the classification
+        min: 1
+        range: string
+      namespaceUri:
+        label: Unique identification of the classification
+        min: 1
+        range: string
+      replacedObjectCodes:
+        label: List of codes of the replaced items
+        max: inf
+        range: string
+      replacingObjectCodes:
+        label: List of codes of the replacing items
+        max: inf
+        range: string
+      revisionDateUtc:
+        label: Date of the revision
+        range: dateTime
+      revisionNumber:
+        label: Revision number
+        range: int
+      status:
+        label: 'Status, can be: Preview, Active or Inactive'
+        min: 1
+        range: string
+      subdivisionsOfUse:
+        label: List of subdivisions (e.g. states) where used
+        max: inf
+        range: string
+      uid:
+        label: Alternative unique global identification
+        range: string
+      versionDateUtc:
+        label: Date of the version
+        range: dateTime
+      versionNumber:
+        label: Version number
+        range: int
+      visualRepresentationUri:
+        label: URI of a visual representation
+        range: string
+  ClassificationProperty:
+    type: ClassificationProperty
+    label: Attributes of a property of a classification. A property can be part of many classifications but the restrictions for the property can differ per classification
+    props:
+      allowedValues:
+        label: List of allowed values
+        max: inf
+        range: ClassificationPropertyValue
+      dataType:
+        label: 'Format for expressing the value of the property: Boolean, Character, Date, Enumeration, Integer, Real, String, Time'
+        range: string
+      description:
+        label: Plain language description of the property
+        range: string
+      dimension:
+        label: "Dimension of the physical quantity in format 'L M T I \u0398 N J', for example '-2 1 0 0 0 0 0'.\n                                                  With\n                                                    L   Length\n                                                    M   Mass\n                                                    T   Time\n                                                    I   Electric current\n                                                    \u0398   Thermodynamic Temperature\n                                                    N   Amount of substance\n                                                    J   Luminous intensity\n"
+        range: string
+      dimensionLength:
+        label: The Length value of the dimension
+        range: int
+      dimensionMass:
+        label: The Mass value of the dimension
+        range: int
+      dimensionTime:
+        label: The Time value of the dimension
+        range: int
+      dimensionElectricCurrent:
+        label: The Electric Current value of the dimension
+        range: int
+      dimensionThermodynamicTemperature:
+        label: The Thermodynamic Temperature value of the dimension
+        range: int
+      dimensionAmountOfSubstance:
+        label: The Amount Of Substance value of the dimension
+        range: int
+      dimensionLuminousIntensity:
+        label: The Luminous Intensity value of the dimension
+        range: int
+      dynamicParameterPropertyCodes:
+        label: List of codes of the properties which are parameters of the function for a dynamic property. Only applicable for dynamic properties (IsDynamic)
+        max: inf
+        range: string
+      example:
+        label: Illustrate possible use or values of the Property
+        range: string
+      isDynamic:
+        label: True if the value of this property is dependent on other properties (as provided in DynamicParameterPropertyCodes)
+        min: 1
+        range: boolean
+      isRequired:
+        label: Indicates if the property is required to be filled for this classification
+        range: boolean
+      isWritable:
+        label: Indicates if the property value can be changed
+        range: boolean
+      maxExclusive:
+        label: Maximum value of the property, exclusive
+        range: decimal
+      maxInclusive:
+        label: Maximum value of the property, inclusive
+        range: decimal
+      methodOfMeasurement:
+        label: Description of the method of measurement
+        range: string
+      minExclusive:
+        label: Minimum value of the property, exclusive
+        range: decimal
+      minInclusive:
+        label: Minimum value of the property, inclusive
+        range: decimal
+      pattern:
+        label: 'An XML Schema Regular expression for the property value. See for explanation: https://www.regular-expressions.info/xml.html.'
+        range: string
+      physicalQuantity:
+        label: The quantity in plain text
+        range: string
+      possibleValues:
+        label: DEPRECATED - please use allowedValues instead
+        max: inf
+        range: ClassificationPropertyValue
+      predefinedValue:
+        label: Predefined value for the property
+        range: string
+      propertySet:
+        label: Name of the property set
+        range: string
+      propertyValueKind:
+        label: 'Indicates kind of value: Single, Range (2 values expected), List (multiple values expected), Complex (use in combination with ConnectedProperties), ComplexList'
+        range: PropertyValueKind
+      symbol:
+        label: Symbol of the property
+        range: string
+      textFormat:
+        label: The text type, e.g. UTF-8
+        min: 1
+        range: string
+      units:
+        label: List of units
+        max: inf
+        range: string
+      activationDateUtc:
+        label: Date of activation
+        min: 1
+        range: dateTime
+      code:
+        label: Code used originally by the domain
+        min: 1
+        range: string
+      creatorLanguageCode:
+        label: Language code of the creator
+        range: string
+      countriesOfUse:
+        label: List of countries where used
+        max: inf
+        range: string
+      countryOfOrigin:
+        label: Country of origin
+        range: string
+      deActivationDateUtc:
+        label: Date of deactivation
+        range: dateTime
+      definition:
+        label: Definition
+        range: string
+      deprecationExplanation:
+        label: Explanation of the deprecation
+        range: string
+      documentReference:
+        label: Reference to a(n official) document
+        range: string
+      name:
+        label: Plain name of the property
+        min: 1
+        range: string
+      namespaceUri:
+        label: Unique identification of the property
+        min: 1
+        range: string
+      replacedObjectCodes:
+        label: List of codes of the replaced items
+        max: inf
+        range: string
+      replacingObjectCodes:
+        label: List of codes of the replacing items
+        max: inf
+        range: string
+      revisionDateUtc:
+        label: Date of the revision
+        range: dateTime
+      revisionNumber:
+        label: Revision number
+        range: int
+      status:
+        label: 'Status, can be: Preview, Active or Inactive'
+        min: 1
+        range: string
+      subdivisionsOfUse:
+        label: List of subdivisions (e.g. states) where used
+        max: inf
+        range: string
+      uid:
+        label: Alternative unique global identification
+        range: string
+      versionDateUtc:
+        label: Date of the version
+        range: dateTime
+      versionNumber:
+        label: Version number
+        range: int
+      visualRepresentationUri:
+        label: URI of a visual representation
+        range: string
+  ClassificationPropertyValue:
+    type: ClassificationPropertyValue
+    label: Attributes of possible values of a property of a classification.
+    props:
+      namespaceUri:
+        label: Globally unique identification of the property
+        range: string
+      code:
+        label: Code of the value
+        range: string
+      description:
+        label: Description of the value
+        range: string
+      bsdd:value:
+        label: The value
+        min: 1
+        range: string
+      sortNumber:
+        label: Sort number (if sorting of the values has been specified)
+        range: int
+  ClassificationRelation:
+    type: ClassificationRelation
+    label: Attributes of a relation of a classification with another classification, can be from a different domain.
+    props:
+      relatedClassificationName:
+        label: relatedClassificationName
+        range: string
+      relatedClassificationUri:
+        label: The namespace uri of the related classification
+        min: 1
+        range: string
+      relationType:
+        label: relationType
+        min: 1
+        range: string
+  Domain:
+    type: Domain
+    label: Contains general information about the domain and the delivered data.
+    props:
+      name:
+        label: The name of the domain
+        min: 1
+        range: string
+      version:
+        label: The version of the domain
+        min: 1
+        range: string
+      namespaceUri:
+        label: The unique identification of the domain
+        min: 1
+        range: string
+      status:
+        label: status
+        range: string
+      releaseDate:
+        label: releaseDate
+        range: dateTime
+      license:
+        label: The type of license for using data of this domain
+        range: string
+      licenseUrl:
+        label: Url with more info about the license
+        range: string
+      copyrightNotice:
+        label: The domain copyright
+        range: string
+      moreInfoUrl:
+        label: Url with more info about the domain
+        range: string
+      lastUpdatedUtc:
+        label: UTC date this domain was last updated
+        min: 1
+        range: dateTime
+      languageCode:
+        label: The language the results will be returned in if no language specified or if specified language is not available
+        min: 1
+        range: string
+      classificationSearch:
+        label: Search for classifications in the domain. Results are limited to max 5000 items.
+        max: inf
+        range: Classification
+      classification:
+        label: Select a classification
+        range: Classification
+  Language:
+    type: Language
+    label: Language
+    props:
+      isocode:
+        label: Unique identification of the language
+        min: 1
+        range: string
+      name:
+        label: Language name
+        min: 1
+        range: string
+  Property:
+    type: Property
+    label: Property
+    props:
+      allowedValues:
+        label: List of allowed values
+        max: inf
+        range: PropertyValue
+      connectedPropertyCodes:
+        label: List of codes of connected properties
+        max: inf
+        range: string
+      dataType:
+        label: 'Format for expressing the value of the property: Boolean, Character, Date, Enumeration, Integer, Real, String, Time'
+        range: string
+      description:
+        label: Plain language description of the property
+        range: string
+      dimension:
+        label: "Dimension of the physical quantity in format 'L M T I \u0398 N J', for example '-2 1 0 0 0 0 0'.\n                                                  With\n                                                    L   Length\n                                                    M   Mass\n                                                    T   Time\n                                                    I   Electric current\n                                                    \u0398   Thermodynamic Temperature\n                                                    N   Amount of substance\n                                                    J   Luminous intensity\n"
+        range: string
+      dimensionLength:
+        label: The Length value of the dimension
+        range: int
+      dimensionMass:
+        label: The Mass value of the dimension
+        range: int
+      dimensionTime:
+        label: The Time value of the dimension
+        range: int
+      dimensionElectricCurrent:
+        label: The Electric current value of the dimension
+        range: int
+      dimensionThermodynamicTemperature:
+        label: The Thermodynamic temperature value of the dimension
+        range: int
+      dimensionAmountOfSubstance:
+        label: The Amount of substance value of the dimension
+        range: int
+      dimensionLuminousIntensity:
+        label: The Luminous Intensity value of the dimension
+        range: int
+      dynamicParameterPropertyCodes:
+        label: List of codes of the properties which are parameters of the function for a dynamic property. Only applicable for dynamic properties (IsDynamic)
+        max: inf
+        range: string
+      example:
+        label: Illustrate possible use or values of the Property
+        range: string
+      isDynamic:
+        label: True if the value of this property is dependent on other properties (as provided in DynamicParameterPropertyCodes)
+        min: 1
+        range: boolean
+      maxExclusive:
+        label: Maximum value of the property, exclusive
+        range: decimal
+      maxInclusive:
+        label: Maximum value of the property, inclusive
+        range: decimal
+      methodOfMeasurement:
+        label: Description of the method of measurement
+        range: string
+      minExclusive:
+        label: Minimum value of the property, exclusive
+        range: decimal
+      minInclusive:
+        label: Minimum value of the property, inclusive
+        range: decimal
+      pattern:
+        label: 'An XML Schema Regular expression for the property value. See for explanation: https://www.regular-expressions.info/xml.html.'
+        range: string
+      physicalQuantity:
+        label: The quantity in plain text
+        range: string
+      propertyValueKind:
+        label: 'Indicates kind of value: Single, Range (2 values expected), List (multiple values expected), Complex (use in combination with ConnectedProperties), ComplexList'
+        range: PropertyValueKind
+      possibleValues:
+        label: DEPRECATED - please use allowedValues
+        max: inf
+        range: PropertyValue
+      relations:
+        label: List of related properties
+        max: inf
+        range: PropertyRelation
+      textFormat:
+        label: The text type, e.g. UTF-8
+        range: string
+      units:
+        label: List of units
+        max: inf
+        range: string
+      activationDateUtc:
+        label: Date of activation
+        min: 1
+        range: dateTime
+      code:
+        label: Code used originally by the domain
+        min: 1
+        range: string
+      creatorLanguageCode:
+        label: Language code of the creator
+        range: string
+      countriesOfUse:
+        label: List of countries where used
+        max: inf
+        range: string
+      countryOfOrigin:
+        label: Country of origin
+        range: string
+      deActivationDateUtc:
+        label: Date of deactivation
+        range: dateTime
+      definition:
+        label: Definition
+        range: string
+      deprecationExplanation:
+        label: Explanation of the deprecation
+        range: string
+      documentReference:
+        label: Reference to a(n official) document
+        range: string
+      name:
+        label: Plain name of the property
+        min: 1
+        range: string
+      namespaceUri:
+        label: Unique identification of the property
+        min: 1
+        range: string
+      replacedObjectCodes:
+        label: List of codes of the replaced items
+        max: inf
+        range: string
+      replacingObjectCodes:
+        label: List of codes of the replacing items
+        max: inf
+        range: string
+      revisionDateUtc:
+        label: Date of the revision
+        range: dateTime
+      revisionNumber:
+        label: Revision number
+        range: int
+      status:
+        label: 'Status, can be: Preview, Active or Inactive'
+        min: 1
+        range: string
+      subdivisionsOfUse:
+        label: List of subdivisions (e.g. states) where used
+        max: inf
+        range: string
+      uid:
+        label: Alternative unique global identification
+        range: string
+      versionDateUtc:
+        label: Date of the version
+        range: dateTime
+      versionNumber:
+        label: Version number
+        range: int
+      visualRepresentationUri:
+        label: URI of a visual representation
+        range: string
+  PropertyValue:
+    type: PropertyValue
+    label: Attributes of possible values of a property.
+    props:
+      namespaceUri:
+        label: Globally unique identification of the property
+        range: string
+      code:
+        label: Code of the value (unique within the property)
+        range: string
+      description:
+        label: Description of the value
+        range: string
+      bsdd:value:
+        label: The value (unique within the property)
+        min: 1
+        range: string
+      sortNumber:
+        label: Sort number (if sorting of the values has been specified)
+        range: int
+  PropertyRelation:
+    type: PropertyRelation
+    label: Attributes of a relation of a property with another property, can be from a different domain.
+    props:
+      relatedPropertyName:
+        label: Name of the related property
+        range: string
+      relatedPropertyUri:
+        label: The namespace uri of the related property
+        min: 1
+        range: string
+      relationType:
+        label: Type of the relation with the reference property
+        min: 1
+        range: string
+  ReferenceDocument:
+    type: ReferenceDocument
+    label: ReferenceDocument
+    props:
+      title:
+        label: Unique identification of the reference document
+        min: 1
+        range: string
+      name:
+        label: Reference document name
+        min: 1
+        range: string
+      date:
+        label: Reference document date
+        min: 1
+        range: dateTime
+  Unit:
+    type: Unit
+    label: Unit
+    props:
+      code:
+        label: Unique identification of the unit
+        min: 1
+        range: string
+      name:
+        label: Unit name
+        min: 1
+        range: string
+      symbol:
+        label: Unit symbol
+        range: string
+rbac:
+  roles: {}

--- a/bssd-soml-template.yaml
+++ b/bssd-soml-template.yaml
@@ -1,0 +1,33 @@
+id: /soml/bsdd
+label:       # label for the schema
+creator:     # creator for the schema
+created:     # date the schema is created
+updated:     # date the schema is updated
+versionInfo: # version of the schema
+config:
+# optional section with configurations used by the Platform
+
+types: {}
+# optional section with configurations used by the Platform
+
+prefixes:
+  bsdd: https://identifier.buildingsmart.org/def#
+# define prefixes for this schema domain
+
+specialPrefixes:
+  # base IRI for data (resources)
+  base_iri: https://identifier.buildingsmart.org/uri/
+  # default namespace for vocabulary (ontology) terms
+  vocab_iri: https://identifier.buildingsmart.org/def#
+  # prefix corresponding to the vocab IRI
+  vocab_prefix: bsdd
+
+properties: {}
+# define global property definitions
+
+objects: {}
+# define objects and their properties
+
+rbac:
+  # define role based access control to objects and properties
+  roles: {}

--- a/graphql2soml.py
+++ b/graphql2soml.py
@@ -1,0 +1,189 @@
+import json
+
+import requests
+import yaml
+
+# TODO: Move these to a .conf file that will be read by the tool
+
+# URL of the GraphQL API that this tool will convert to SOML
+GRAPHQL_API = "https://bs-dd-api-prototype.azurewebsites.net/graphql"
+
+# Path to the SOML template to use as a base
+SOML_TEMPLATE = "bssd-soml-template.yaml"
+
+# Path to an introspection GraphQL query
+INTROSPECTION_QUERY = "graphql-IntrospectionQuery.graphql"
+
+# Path to a JSON where the introspection schema will be saved to
+INTROSPECTION_JSON = "bsdd-graphql-schema-orig.json"
+
+# Path to a YAML file where the final SOML schema will be saved to
+PRODUCED_SOML = "bsdd-graphql-soml-orig.yaml"
+
+# Default namespace
+NAMESPACE = "bsdd:"
+
+# Mapping between GraphQL types and their range in SOML
+GRAPHQL_TO_SOML_RANGE = {
+    "Int": "int",
+    "Float": "double",
+    "String": "string",
+    "Boolean": "boolean",
+    "ID": "iri",
+    "Long": "long",
+    "Short": "short",
+    "Byte": "byte",
+    "UnsignedLong": "unsignedLong",
+    "UnsignedInteger": "unsignedInt",
+    "UnsignedShort": "unsignedShort",
+    "UnsignedByte": "unsignedByte",
+    "Decimal": "decimal",
+    "Integer": "integer",
+    "PositiveInteger": "positiveInteger",
+    "NonPositiveInteger": "nonPositiveInteger",
+    "NegativeInteger": "negativeInteger",
+    "NonNegativeInteger": "nonNegativeInteger",
+    "NegativeFloat": "negativeFloat",
+    "NonNegativeFloat": "nonNegativeFloat",
+    "PositiveFloat": "positiveFloat",
+    "NonPositiveFloat": "nonPositiveFloat",
+    "DateTime": "dateTime",
+    "Time": "time",
+    "Date": "date",
+    "Year": "year",
+    "YearMonth": "yearMonth",
+    "Literal": "literal"
+}
+
+# There are some properties that cannot use reserved words
+RESERVED_PROPERTY_NAMES = ['value']
+
+
+# Loads the content of given file path as a string.
+def load_file(path):
+    with open(path) as f:
+        content = f.read()
+        f.close()
+    return content
+
+
+# Writes the given content to the specified file path
+def save_file(path, content):
+    with open(path, 'w') as f:
+        f.write(content)
+        f.close()
+
+
+# Performs an introspection request and returns the JSON schema.
+def introspect(graphql_api, introspection_query):
+    response = requests.post(graphql_api, json={
+        "query": introspection_query,
+        "operationName": "IntrospectionQuery"
+    }, headers={
+        "content-type": "application/json",
+        "accept": "application/json"
+    })
+
+    return response.json()
+
+
+def to_soml_object(t):
+    soml_obj = {
+        "type": f"{t['name']}",
+        "label": sanitize_label(t["description"] or t["name"]),
+        "props": to_soml_fields(t)
+    }
+    if "OBJECT" not in t["kind"]:
+        soml_obj["kind"] = "abstract"
+    return soml_obj
+
+
+def to_soml_enum(t):
+    values = list()
+    for value in t["enumValues"]:
+        enum_value = {
+            "name": value["name"]
+        }
+        if value["description"]:
+            enum_value["label"] = sanitize_label(value["description"])
+        values.append(enum_value)
+    return {
+        "values": values
+    }
+
+
+def to_soml_fields(t):
+    fields = {}
+
+    for gql_field in t["fields"]:
+        name = gql_field["name"]
+        if name in RESERVED_PROPERTY_NAMES:
+            name = NAMESPACE + name
+        field = {
+            "label": sanitize_label(gql_field["description"] or gql_field["name"])
+        }
+        resolve_field_type(gql_field, gql_field["type"], field)
+        fields[name] = field
+    return fields
+
+
+def resolve_field_type(gql_field, gql_field_type, field):
+    kind = gql_field_type["kind"]
+    name = gql_field_type["name"]
+    of_type = gql_field_type["ofType"]
+
+    if "NON_NULL" in kind:
+        field["min"] = 1
+        resolve_field_type(gql_field, of_type, field)
+    elif "LIST" in kind:
+        field["max"] = "inf"
+        resolve_field_type(gql_field, of_type, field)
+    elif "SCALAR" in kind:
+        field["range"] = GRAPHQL_TO_SOML_RANGE[name]
+    else:
+        # OBJECT or ENUM
+        field["range"] = gql_field_type["name"]
+
+    return field
+
+
+def sanitize_label(label):
+    return label.replace("\r\n", "\n")
+
+
+def to_soml(soml, introspection):
+    types = introspection['data']['__schema']['types']
+
+    objects = soml['objects']
+    enums = soml['types']
+
+    for t in types:
+        kind = t['kind']
+        name = str(t['name'])
+        fields = t['fields']
+
+        # Filter system objects
+        if not name.startswith('__') and 'RootQuery' not in name and fields:
+            objects[name] = to_soml_object(t)
+        elif 'ENUM' in kind and not name.startswith('__'):
+            enums[name] = to_soml_enum(t)
+
+    return soml
+
+
+def main():
+    # Introspection
+    introspection_query = load_file(INTROSPECTION_QUERY)
+    introspection_schema = introspect(GRAPHQL_API, introspection_query)
+    save_file(INTROSPECTION_JSON, json.dumps(introspection_schema, indent=2))
+
+    # SOML
+    soml_template = yaml.safe_load(load_file(SOML_TEMPLATE))
+    soml = to_soml(soml_template, introspection_schema)
+    soml_yaml = yaml.safe_dump(soml, sort_keys=False, width=99999)
+    save_file(PRODUCED_SOML, soml_yaml)
+    print(soml_yaml)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implemented Python utility script for converting GraphQL
introspection to a SOML schema. The process is as follows:

- Performs GraphQL introspection to given GraphQL API and saves
  it into local file
- Converts the introspection to a SOML schema and saves it locally

The conversion is based on a SOML schema template.
Running the script again will reproduce the results.

Added .gitignore