### PR TITLE
Added data export from bSDD GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Python
 .venv/
+
+# Export
+data/

--- a/README.org
+++ b/README.org
@@ -63,6 +63,51 @@ The generated SOML schema is valid and can be used immediately. However, there a
 The purpose of the generated SOML schema is to serve as a starting point (instead of starting from scratch) for resolving the issues and improving the schema.
 Once this is done, the resulting schema will be saved in [[./bsdd-graphql-soml-refact.yaml][bsdd-graphql-soml-refact.yaml]].
 
+** Exporting bSDD data
+
+The repository includes several Python scripts used to work with bSDD data for which we need to create a virtual Python enthronement
+before using them:
+
+- Create a virtual environment with ~python3.9 -m venv .venv~
+- Activate it ~source .venv/bin/activate~
+- Install the required libraries ~pip install -r requirements.txt~
+
+*** GraphQL Data Dumps
+
+The repository includes a Python script ~bsdd2json.py~ that can connect to the bSDD GraphQL API and export all objects in the
+GraphQL schema as JSONs including domains, classifications, classification properties etc.
+
+The exported data will be located under the ~data/~ directory once the script is executed. Running this script takes around ~10 hours due to
+the large quantity of classifications and classification properties in the GraphQL API.
+
+The overall process is of the script is
+
+- Exports all "root" types with their complete information except relations (object properties)
+  - bSDD domains in ~data/domains.json~ (~Domain~ in GraphQL)
+  - Countries in ~data/domains.json~ (~Country~ in GraphQL)
+  - Languages in ~data/languages.json~ (~Language~ in GraphQL)
+  - Measurements units in ~data/units.json~ (~Unit~ in GraphQL)
+  - Reference documents in ~data/reference_documents.json~ (~ReferenceDocument~ in GraphQL)
+- For each exported domain, it creates a sub directory and exports all classification in that domain in separate JSONs (~Classification~ in GraphQL)
+- Collects all unique classification properties, tries to resolve them as global properties and finally exports them in ~properties.json~ (~Property~ in GraphQL)
+
+*** Exporting Data
+
+The repository includes a Python script ~bsdd_export.py~ which works with the GraphQL queries within the ~graphql/~ folder.
+It can invoke given query with or without variables and return the response to the user in JSON.
+
+Example for getting all domains:
+
+#+begin_src bash
+python bsdd_export.py getDomains -o domains.json
+#+end_src
+
+Example for getting particular domain:
+
+#+begin_src bash
+python bsdd_export.py getDomain -v "URI=https://identifier.buildingsmart.org/uri/buildingsmart/ifc-4.3" -o ifc-4.3.json
+#+end_src
+
 ** Original vs Refactored Files
 bsdd-graphql-voyager-orig.html
 bsdd-graphql-voyager-refact.html
@@ -114,7 +159,7 @@ Property names should conform to naming conventions and be spelled consistently
   ~<http://bsdd.buildingsmart.org/relation/def#>~.
   You can see this problem by fetching:
 : curl -s -H Accept:text/turtle  https://identifier.buildingsmart.org/uri/bs-agri/fruitvegs-1.0/class/apple
-  
+
 ** Use the same URL for Data and for Web Pages
 bSDD has implemented "entity URLs", i.e. for each kind of entity it can return its data in JSON or RDF:
 #+begin_src
@@ -350,7 +395,7 @@ This difference leads to very inconsistent results from the different APIs.
 ** Improve URL Structure and Consistency
 - Almost all domain URLs have the same structure: ~https://identifier.buildingsmart.org/uri/<org>/<domain>-<ver>~.
   There are only 2 exceptions:
-#+begin_src 
+#+begin_src
 http://otl.amsterdam.nl
 http://rdf.vegdata.no/V440/v440-owl
 #+end_src
@@ -442,7 +487,7 @@ There are differences and omissions in some of the formats, as described in the 
 It would be better to return the same content in each of the formats.
 
 
-| Classification/property | GraphQL      | JSON API                                   | RDF API                |comment 
+| Classification/property | GraphQL      | JSON API                                   | RDF API                |comment
 |------------------------+--------------+--------------------------------------------+------------------------+--------------------------------------------|
 | Classification/childs  | childs       | parentClassificationReference.namespaceUri | NONE                   | GraphQL points to child, JSON points to parent (1)
 | Classification/domain  | NONE         | NONE                                       | bsdd:Domain            | GraphQL and JSON API do not return property ~domain~ whereas RDF API returns it  |
@@ -608,7 +653,7 @@ Here is a list of all strings that are candidates to be converted to objects:
 - ~relatedIfcEntityNames~: since IFC is present as a bSDD Domain, could be converted to a relation to the respective IFC Classification
 
   TODO: PropSet should be made an entoity, it's too important to be a mere string
-  
+
 ** Property vs ClassificationProperty: Use Distinct URLs
 ~Property~ and ~ClassificationProperty~ are two different classes, but the latter does not have a distinct URL in GraphQL and JSON.
 We can say that the same URL is overloaded to identify entities of both classes.
@@ -747,7 +792,7 @@ We implemented a lot (but not all) of the improvements suggested above by using 
 - Converting it to RDF using [[https://sparql-anything.cc/][SPARQL Anything]]
 - Loading it to [[https://www.ontotext.com/products/graphdb/][GraphDB]]
 - Refactoring the RDF using SPARQL Update
-- 
+-
 
 ** Fetching bSDD GraphQL JSON
 Although bSDD is available in RDF, we decided to fetch all data in GraphQL JSON due to the RDF defects described above.
@@ -872,7 +917,7 @@ It is converted to the following "raw" RDF (shortened for brevity):
 
 [ rdf:type                       fx:root ;
   bsdd:activationDateUtc         "2022-12-31T00:00:00" ;
-  bsdd:classificationProperties  [ rdfs:member  
+  bsdd:classificationProperties  [ rdfs:member
       [ bsdd:dataType              "Real" ;
         bsdd:description           "Indicates the Maximum transmission attenuation of feeder." ;
         bsdd:name                  "MaximumTransmissionAttenuation" ;
@@ -890,7 +935,7 @@ It is converted to the following "raw" RDF (shortened for brevity):
   bsdd:domainNamespaceUri        "https://identifier.buildingsmart.org/uri/buildingsmart/ifc-4.3" ;
   bsdd:name                      "IfcCableSegment.CABLESEGMENT" ;
   bsdd:namespaceUri              "https://identifier.buildingsmart.org/uri/buildingsmart/ifc-4.3/class/IfcCableSegmentCABLESEGMENT" ;
-  bsdd:parentClassificationReference 
+  bsdd:parentClassificationReference
       [ bsdd:code          "IfcCableSegment" ;
         bsdd:name          "IfcCableSegment" ;
         bsdd:namespaceUri  "https://identifier.buildingsmart.org/uri/buildingsmart/ifc-4.3/class/IfcCableSegment"
@@ -952,7 +997,7 @@ It does the following:
 This SPARQL Update script is class-independent (works on any Raw bSDD RDF), so it can be used in two ways:
 - On an individual RDF file by using Jena's ~update~, for testing
 - After loading all data to [[https://www.ontotext.com/products/graphdb/][GraphDB]], to transform all of it in one go
-  
+
 * Acknowledgements
 This work is part of the ACCORD project that has received funding from the European Union’s Horizon Europe research and innovation programme under grant agreement no. 101056973
 TODO compare to [[https://vttgroup.sharepoint.com/:p:/r/sites/EU-projectpreparationDigitalpermitsandcompliancecheck/_layouts/15/Doc.aspx?sourcedoc=%7BB9913B35-D290-4391-9588-0322584EF3BC%7D&file=ACCORD_EAB_meeting_02-12-2022.pptx&action=edit&mobileredirect=true][this pres]].

--- a/bsdd2json.py
+++ b/bsdd2json.py
@@ -1,0 +1,159 @@
+import json
+import logging
+import os
+import re
+import sys
+
+from graphql import bsdd_graphql_api, bsdd_graphql_api as bsdd_api
+
+logging.basicConfig(
+    format="%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s",
+    stream=sys.stdout,
+    level=logging.getLevelName("INFO")
+)
+logger = logging.getLogger(__name__)
+
+DATA_DIR = './data/'
+GLOBAL_PROPERTIES_MAPPING_FILE = DATA_DIR + 'properties.json'
+
+BSDD_URI_PREFIX = "https://identifier.buildingsmart.org/uri/"
+
+
+def save_file(path, content):
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+# Export functions
+
+
+def export_domains(target_dir):
+    logger.info("Exporting domains")
+    domains = bsdd_api.get_domains()
+    save_file(target_dir + '/domains.json', json.dumps(domains))
+    logger.info(f"Exported {len(domains)} domains")
+    return domains
+
+
+def export_languages(target_dir):
+    logger.info("Exporting languages")
+    languages = bsdd_graphql_api.get_languages()
+    save_file(target_dir + '/languages.json', json.dumps(languages))
+    logger.info(f"Exported {len(languages)} languages")
+    return languages
+
+
+def export_countries(target_dir):
+    logger.info("Exporting countries")
+    countries = bsdd_graphql_api.get_countries()
+    save_file(target_dir + '/countries.json', json.dumps(countries))
+    logger.info(f"Exported {len(countries)} countries")
+    return countries
+
+
+def export_units(target_dir):
+    logger.info("Exporting units")
+    units = bsdd_graphql_api.get_units()
+    save_file(target_dir + '/units.json', json.dumps(units))
+    logger.info(f"Exported {len(units)} units")
+    return units
+
+
+def export_reference_documents(target_dir):
+    logger.info("Exporting reference documents")
+    reference_documents = bsdd_graphql_api.get_reference_documents()
+    save_file(target_dir + '/reference_documents.json', json.dumps(reference_documents))
+    logger.info(f"Exported {len(reference_documents)} reference documents")
+    return reference_documents
+
+
+def get_domain_folder(target_dir, domain_id):
+    if BSDD_URI_PREFIX in domain_id:
+        domain_id = domain_id.removeprefix(BSDD_URI_PREFIX)
+    return f"{target_dir}domains/" + re.sub("[+/:]", "_", domain_id)
+
+
+def export_domain_classifications(target_dir, domains):
+    exported_classifications = list()
+    failed_domains = list()
+
+    for domain_index, domain in enumerate(domains):
+        domain_id = domain["namespaceUri"]
+        # Create dir for domain classifications
+        domain_dir = get_domain_folder(target_dir, domain_id)
+        os.makedirs(domain_dir, exist_ok=True)
+        try:
+            domain_classifications = bsdd_api.get_domain_classifications(domain_id)
+            count = len(domain_classifications)
+            logger.info(f"Exporting {count} classifications for domain {domain_id}")
+            for index, classification_metadata in enumerate(domain_classifications):
+                classification_id = classification_metadata["namespaceUri"]
+                classification_name = classification_metadata["name"]
+                classification_code = classification_metadata["code"]
+                try:
+                    classification = bsdd_api.get_classification(classification_id)
+                    save_file(f"{domain_dir}/{classification_code}.json", json.dumps(classification))
+                    exported_classifications.append(classification)
+                    logger.info(f"Exported classification {classification_name} for domain {domain_id} ({index + 1}/{count})")
+                except Exception as ex:
+                    logger.error(f"Could not process classification {classification_name} for domain {domain_id}")
+                    logger.error(ex)
+            logger.info(f"\nExported {count} classifications for domain {domain_id} ({domain_index + 1}/{len(domains)})\n")
+        except Exception as ex:
+            logger.error(f"Could not process domain {domain_id}")
+            logger.error(ex)
+            failed_domains.append(domain_id)
+    if len(failed_domains) > 0:
+        logger.error("Failed domains: ")
+        print(failed_domains)
+
+    return exported_classifications
+
+
+def export_global_properties(target_dir, classifications):
+    unique_properties = set()
+    logger.info(f"Collecting unique properties from {len(classifications)} classifications")
+
+    for classification in classifications:
+        classification_properties = classification["properties"]
+        if classification_properties is not None:
+            for classification_property in classification_properties:
+                if classification_property is not None:
+                    unique_properties.add(classification_property["namespaceUri"])
+    logger.info(f"Collected {len(unique_properties)} unique classification properties")
+
+    global_properties = {}
+    failed_properties = list()
+    for index, property_id in enumerate(unique_properties):
+        try:
+            property_data = bsdd_api.get_global_property(property_id)
+            global_properties[property_id] = property_data
+            logger.info(f"Processed global property {property_id} ({index + 1}/{len(unique_properties)})")
+        except Exception as ex:
+            logger.error(f"Could not process global property {property_id}")
+            logger.error(ex)
+            failed_properties.append(property_id)
+
+    save_file(f"{target_dir}properties.json", json.dumps(list(global_properties.values())))
+    logger.info(f"Exported {len(global_properties)} global properties")
+
+    if len(failed_properties) > 0:
+        logger.error("Failed global properties: ")
+        print(failed_properties)
+
+
+def main():
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+    domains = export_domains(DATA_DIR)
+    export_languages(DATA_DIR)
+    export_countries(DATA_DIR)
+    export_units(DATA_DIR)
+    export_reference_documents(DATA_DIR)
+
+    classifications = export_domain_classifications(DATA_DIR, domains)
+    export_global_properties(DATA_DIR, classifications)
+
+
+if __name__ == "__main__":
+    main()

--- a/bsdd_export.py
+++ b/bsdd_export.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+
+from graphql import bsdd_graphql_api as bsdd_api
+
+argparser = argparse.ArgumentParser(
+    prog="bSDD Data Exporter",
+    description="CLI for exporting data from bSDD GraphQL API"
+)
+argparser.add_argument('queryname')
+argparser.add_argument('-v', '--var', action='append', required=False)
+argparser.add_argument('-o', '--output', required=False)
+arguments = argparser.parse_args()
+
+
+def save_file(path, content):
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def main():
+    query_name = arguments.queryname.removesuffix('.graphql')
+    query = bsdd_api.read_query(f"{query_name}.graphql")
+
+    variables = {}
+    if arguments.var:
+        for var in arguments.var:
+            parts = var.split('=')
+            variables[parts[0].strip()] = parts[1].strip()
+
+    response = bsdd_api.query_graphql(bsdd_api.GRAPHQL_API, query, variables)
+    response_string = json.dumps(response, indent=2)
+
+    if arguments.output:
+        save_file(arguments.output, response_string)
+    else:
+        print(response_string)
+
+
+if __name__ == "__main__":
+    main()

--- a/graphql/bsdd_graphql_api.py
+++ b/graphql/bsdd_graphql_api.py
@@ -1,0 +1,82 @@
+import logging
+from pathlib import Path
+import requests
+
+logger = logging.getLogger(__name__)
+
+GRAPHQL_API = "https://test.bsdd.buildingsmart.org/graphql"
+
+
+def read_query(query_file):
+    current_dir = Path(__file__).parent.absolute()
+    return open(current_dir.name + '/' + query_file, 'r').read()
+
+
+def query_graphql(endpoint, query, variables=None):
+    response = requests.post(endpoint, json={
+        "query": query,
+        "variables": variables or {}
+    })
+    return response.json()["data"]
+
+
+QUERY_GET_DOMAINS = read_query('getDomains.graphql')
+QUERY_GET_LANGUAGES = read_query('getLanguages.graphql')
+QUERY_GET_COUNTRIES = read_query('getCountries.graphql')
+QUERY_GET_UNITS = read_query('getUnits.graphql')
+QUERY_GET_REF_DOCUMENTS = read_query('getReferenceDocuments.graphql')
+QUERY_GET_DOMAIN_CLASSIFICATIONS = read_query('getDomainClassifications.graphql')
+QUERY_GET_CLASSIFICATION = read_query('getClassification.graphql')
+QUERY_GET_CLASSIFICATION_PROPERTIES = read_query('../old/getClassificationProperties.graphql')
+QUERY_GET_PROPERTY = read_query('getProperty.graphql')
+
+
+def get_domains():
+    return query_graphql(GRAPHQL_API, QUERY_GET_DOMAINS)["domains"]
+
+
+def get_languages():
+    return query_graphql(GRAPHQL_API, QUERY_GET_LANGUAGES)["languages"]
+
+
+def get_countries():
+    return query_graphql(GRAPHQL_API, QUERY_GET_COUNTRIES)["countries"]
+
+
+def get_units():
+    return query_graphql(GRAPHQL_API, QUERY_GET_UNITS)["units"]
+
+
+def get_reference_documents():
+    return query_graphql(GRAPHQL_API, QUERY_GET_REF_DOCUMENTS)[
+        "referenceDocuments"]
+
+
+def get_domain_classifications(domain):
+    result = query_graphql(GRAPHQL_API, QUERY_GET_DOMAIN_CLASSIFICATIONS, {
+        "URI": domain
+    })
+    # Some domains seem to lack classifications
+    if result["domain"] and result["domain"]["classificationSearch"]:
+        return result["domain"]["classificationSearch"]
+    return list()
+
+
+# This method gets only the literal properties of classifications
+def get_classification(classification):
+    return query_graphql(GRAPHQL_API, QUERY_GET_CLASSIFICATION, {
+        "URI": classification
+    })["classification"]
+
+
+# Note: Used only in bsdd2csv
+def get_classification_object_properties(classification):
+    return query_graphql(GRAPHQL_API, QUERY_GET_CLASSIFICATION_PROPERTIES, {
+        "URI": classification
+    })["classification"]
+
+
+def get_global_property(property_id):
+    return query_graphql(GRAPHQL_API, QUERY_GET_PROPERTY, {
+        "URI": property_id
+    })["property"]

--- a/graphql/getClassification.graphql
+++ b/graphql/getClassification.graphql
@@ -1,0 +1,101 @@
+query getClassification($URI: String!) {
+  classification(namespaceUri: $URI) {
+    namespaceUri
+    __typename
+    classificationType
+    relatedIfcEntityNames
+    synonyms
+    referenceCode
+    properties {
+      namespaceUri
+      __typename
+      allowedValues {
+        namespaceUri
+        __typename
+        code
+        description
+        value
+        sortNumber
+      }
+      dataType
+      description
+      dimension
+      dimensionLength
+      dimensionMass
+      dimensionTime
+      dimensionElectricCurrent
+      dimensionThermodynamicTemperature
+      dimensionAmountOfSubstance
+      dimensionLuminousIntensity
+      dynamicParameterPropertyCodes
+      example
+      isDynamic
+      isRequired
+      isWritable
+      maxExclusive
+      maxInclusive
+      methodOfMeasurement
+      minExclusive
+      minInclusive
+      pattern
+      physicalQuantity
+      predefinedValue
+      propertySet
+      propertyValueKind
+      symbol
+      # Non nullable by definition, returns nulls
+      # textFormat
+      units
+      activationDateUtc
+      code
+      creatorLanguageCode
+      countriesOfUse
+      countryOfOrigin
+      deActivationDateUtc
+      definition
+      deprecationExplanation
+      documentReference
+      name
+      replacedObjectCodes
+      replacingObjectCodes
+      revisionDateUtc
+      revisionNumber
+      status
+      subdivisionsOfUse
+      uid
+      versionDateUtc
+      versionNumber
+      visualRepresentationUri
+    }
+    relations {
+      relatedClassificationUri
+      __typename
+      relatedClassificationName
+      relationType
+    }
+    childs {
+      namespaceUri
+      __typename
+    }
+    activationDateUtc
+    code
+    creatorLanguageCode
+    countriesOfUse
+    countryOfOrigin
+    deActivationDateUtc
+    definition
+    deprecationExplanation
+    documentReference
+    name
+    replacedObjectCodes
+    replacingObjectCodes
+    revisionDateUtc
+    revisionNumber
+    status
+    subdivisionsOfUse
+    uid
+    versionDateUtc
+    versionNumber
+    visualRepresentationUri
+  }
+}

--- a/graphql/getCountries.graphql
+++ b/graphql/getCountries.graphql
@@ -1,0 +1,7 @@
+query getCountries {
+    countries {
+        __typename
+        code
+        name
+    }
+}

--- a/graphql/getDomain.graphql
+++ b/graphql/getDomain.graphql
@@ -1,0 +1,16 @@
+query getDomain($URI: String!) {
+  domain(namespaceUri: $URI) {
+    namespaceUri
+    __typename
+    name
+    version
+    status
+    releaseDate
+    license
+    licenseUrl
+    copyrightNotice
+    moreInfoUrl
+    lastUpdatedUtc
+    languageCode
+  }
+}

--- a/graphql/getDomainClassifications.graphql
+++ b/graphql/getDomainClassifications.graphql
@@ -1,0 +1,9 @@
+query getDomainClassifications($URI: String!) {
+    domain(namespaceUri: $URI) {
+        classificationSearch {
+            namespaceUri
+            name
+            code
+        }
+    }
+}

--- a/graphql/getDomains.graphql
+++ b/graphql/getDomains.graphql
@@ -1,0 +1,16 @@
+query getDomains {
+    domains {
+        namespaceUri
+        __typename
+        name
+        version
+        status
+        releaseDate
+        license
+        licenseUrl
+        copyrightNotice
+        moreInfoUrl
+        lastUpdatedUtc
+        languageCode
+    }
+}

--- a/graphql/getLanguages.graphql
+++ b/graphql/getLanguages.graphql
@@ -1,0 +1,7 @@
+query getLanguages {
+    languages {
+        __typename
+        isocode
+        name
+    }
+}

--- a/graphql/getProperty.graphql
+++ b/graphql/getProperty.graphql
@@ -1,0 +1,64 @@
+query getProperty($URI: String!) {
+  property(namespaceUri: $URI) {
+    namespaceUri
+    __typename
+    allowedValues {
+      namespaceUri
+      __typename
+      code
+      description
+      value
+      sortNumber
+    }
+    connectedPropertyCodes
+    dataType
+    description
+    dimension
+    dimensionLength
+    dimensionMass
+    dimensionTime
+    dimensionElectricCurrent
+    dimensionThermodynamicTemperature
+    dimensionAmountOfSubstance
+    dimensionLuminousIntensity
+    dynamicParameterPropertyCodes
+    example
+    isDynamic
+    maxExclusive
+    maxInclusive
+    methodOfMeasurement
+    minExclusive
+    minInclusive
+    pattern
+    physicalQuantity
+    propertyValueKind
+    relations {
+      relatedPropertyUri
+      __typename
+      relatedPropertyName
+      relationType
+    }
+    textFormat
+    units
+    activationDateUtc
+    code
+    creatorLanguageCode
+    countriesOfUse
+    countryOfOrigin
+    deActivationDateUtc
+    definition
+    deprecationExplanation
+    documentReference
+    name
+    replacedObjectCodes
+    replacingObjectCodes
+    revisionDateUtc
+    revisionNumber
+    status
+    subdivisionsOfUse
+    uid
+    versionDateUtc
+    versionNumber
+    visualRepresentationUri
+  }
+}

--- a/graphql/getReferenceDocuments.graphql
+++ b/graphql/getReferenceDocuments.graphql
@@ -1,0 +1,8 @@
+query getReferenceDocuments {
+    referenceDocuments {
+        __typename
+        title
+        name
+        date
+    }
+}

--- a/graphql/getUnits.graphql
+++ b/graphql/getUnits.graphql
@@ -1,0 +1,8 @@
+query getUnits {
+    units {
+        __typename
+        code
+        name
+        symbol
+    }
+}

--- a/graphql2soml.py
+++ b/graphql2soml.py
@@ -62,16 +62,13 @@ RESERVED_PROPERTY_NAMES = ['value']
 # Loads the content of given file path as a string.
 def load_file(path):
     with open(path) as f:
-        content = f.read()
-        f.close()
-    return content
+        return f.read()
 
 
 # Writes the given content to the specified file path
 def save_file(path, content):
     with open(path, 'w') as f:
         f.write(content)
-        f.close()
 
 
 # Performs an introspection request and returns the JSON schema.

--- a/old/bsdd2csv.py
+++ b/old/bsdd2csv.py
@@ -1,0 +1,235 @@
+import csv
+import logging
+import os
+
+import pandas as pd
+
+from graphql import bsdd_graphql_api as bsdd_api
+
+GRAPHQL_API = "https://bs-dd-api-prototype.azurewebsites.net/graphql"
+BSDD_API = "https://identifier.buildingsmart.org/uri/buildingsmart/"
+
+logging.basicConfig(
+    format="%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  %(message)s",
+    level=logging.getLevelName("INFO")
+)
+logger = logging.getLogger(__name__)
+
+
+# UTILITIES
+
+def save_csv(data, file_path):
+    fieldnames = list(data[0].keys())
+    with open(file_path, 'w', encoding='UTF8', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def export_root_data():
+    domains = bsdd_api.get_domains()
+    save_csv(domains, '../data/domains.csv')
+    logger.info(f"Saved {len(domains)} domains")
+
+    languages = bsdd_api.get_languages()
+    save_csv(languages, '../data/languages.csv')
+    logger.info(f"Saved {len(languages)} languages")
+
+    countries = bsdd_api.get_countries()
+    save_csv(countries, '../data/countries.csv')
+    logger.info(f"Saved {len(countries)} countries")
+
+    units = bsdd_api.get_units()
+    save_csv(units, '../data/units.csv')
+    logger.info(f"Saved {len(units)} units")
+
+    reference_documents = bsdd_api.get_reference_documents()
+    save_csv(reference_documents, '../data/reference_documents.csv')
+    logger.info(f"Saved {len(reference_documents)} reference documents")
+
+
+def export_domain_classifications_mapping():
+    domains = pd.read_csv('../data/domains.csv')['id'].tolist()
+
+    mapping = open('../data/domain_classifications.csv', 'w', encoding='UTF8',
+                   newline='')
+    writer = csv.writer(mapping)
+    writer.writerow(['domain', 'classification'])
+
+    for domain in domains:
+        classifications = bsdd_api.get_domain_classifications(domain)
+        for classification in classifications:
+            writer.writerow([domain, classification['id']])
+        logger.info(
+            f"Got {len(classifications)} classifications for domain {domain}")
+
+    mapping.close()
+
+
+def export_classifications():
+    classifications = pd.read_csv('../data/domain_classifications.csv')[
+        'classification'].tolist()
+
+    export = open('../data/classifications.csv', 'w', encoding='UTF8',
+                  newline='')
+    writer = csv.writer(export)
+
+    for index, classification_id in enumerate(classifications):
+        classification = bsdd_api.get_classification(classification_id)
+
+        if index == 0:
+            fieldnames = list(classification.keys())
+            writer.writerow(fieldnames)
+        else:
+            writer.writerow(classification.values())
+
+        if index % 100 == 99:
+            logger.info(
+                f"Exported {index + 1} of {len(classifications)} classifications")
+
+    export.close()
+
+
+# Creates mapping between classification and its properties, relations and
+# children (sub-classifications)
+def export_classification_object_properties():
+    classifications = pd.read_csv('../data/domain_classifications.csv')[
+        'classification'].tolist()
+
+    failed_classifications = list()
+
+    classification_properties_file = open(
+        '../data/classification_properties.csv',
+        'w',
+        encoding='UTF8',
+        newline=''
+    )
+    properties_writer = csv.writer(classification_properties_file)
+
+    classification_children_file = open(
+        '../data/classification_children.csv',
+        'w',
+        encoding='UTF8',
+        newline=''
+    )
+    children_writer = csv.writer(classification_children_file)
+    children_writer.writerow(['classification', 'child'])
+
+    classification_relations_file = open(
+        '../data/classification_relations.csv',
+        'w',
+        encoding='UTF8',
+        newline=''
+    )
+    relations_writer = csv.writer(classification_relations_file)
+    relations_writer.writerow(
+        ['classification', 'relationType', 'relationName', 'relation'])
+
+    logger.info(
+        f"Exporting object properties for {len(classifications)} classifications")
+
+    for index, classification_id in enumerate(classifications):
+        try:
+            classification = bsdd_api.get_classification_object_properties(classification_id)
+
+            if index == 0:
+                prop = classification["properties"][0]
+                headers = ['classification']
+                headers.extend(list(prop.keys()))
+                properties_writer.writerow(headers)
+
+            for prop in classification["properties"]:
+                if prop is not None:
+                    row = [classification_id]
+                    row.extend(prop.values())
+                    properties_writer.writerow(row)
+
+            for child in classification["childs"]:
+                if child is not None:
+                    children_writer.writerow([classification_id, child["id"]])
+
+            for relation in classification["relations"]:
+                if relation is not None:
+                    relations_writer.writerow(
+                        [classification_id, relation["type"], relation["name"],
+                         relation["id"]])
+
+            if index % 100 == 99:
+                logger.info(
+                    f"Exported {index + 1} of {len(classifications)} classifications object properties")
+        except Exception as ex:
+            logger.warning(f"Could not export classification {classification_id}")
+            logger.debug(ex)
+            failed_classifications.append(classification_id)
+
+    if len(failed_classifications) > 0:
+        logger.error("Failed classifications:")
+        print(failed_classifications)
+
+
+def export_global_properties():
+    classification_properties = pd.read_csv('../data/classification_properties.csv')['id'].unique()
+    failed_properties = list()
+
+    properties_file = open(
+        '../data/properties.csv',
+        'w',
+        encoding='UTF8',
+        newline=''
+    )
+    properties_writer = csv.writer(properties_file)
+
+    properties_relations_file = open(
+        '../data/properties_relations.csv',
+        'w',
+        encoding='UTF8',
+        newline=''
+    )
+    properties_relations_writer = csv.writer(properties_relations_file)
+    properties_relations_writer.writerow(
+        ['property', 'relationType', 'relationName', 'relation'])
+
+    logger.info(
+        f"Exporting {len(classification_properties)} global properties")
+
+    for index, classification_property in enumerate(classification_properties):
+        try:
+            global_property = bsdd_api.get_global_property(classification_property)
+
+            if global_property["relations"]:
+                for relation in global_property["relations"]:
+                    properties_relations_writer.writerow([classification_property, relation.values()])
+            global_property.pop("relations")
+
+            if index == 0:
+                # Headers
+                properties_writer.writerow(list(global_property.keys()))
+
+            properties_writer.writerow(global_property.values())
+
+            if index % 100 == 99:
+                logger.info(
+                    f"Exported {index + 1} of {len(classification_properties)} global properties")
+
+        except Exception as ex:
+            logger.warning(f"Could not export global property {classification_property}")
+            logger.debug(ex)
+            failed_properties.append(classification_property)
+
+    if len(failed_properties) > 0:
+        logger.error("Failed global properties:")
+        print(failed_properties)
+
+
+def main():
+    os.makedirs('../data/', exist_ok=True)
+
+    export_root_data()
+    export_domain_classifications_mapping()
+    export_classifications()
+    export_classification_object_properties()
+    export_global_properties()
+
+
+if __name__ == "__main__":
+    main()

--- a/old/getClassificationProperties.graphql
+++ b/old/getClassificationProperties.graphql
@@ -1,0 +1,78 @@
+query getClassificationProperties($CLASSIFICATION: String!) {
+  classification(namespaceUri: $CLASSIFICATION, includeChilds: true) {
+    id: namespaceUri
+    __typename
+    name
+    properties {
+      id: namespaceUri
+      __typename
+      allowedValues {
+        id: namespaceUri
+        __typename
+        code
+        description
+        value
+        sortNumber
+      }
+      dataType
+      description
+      dimension
+      dimensionLength
+      dimensionMass
+      dimensionTime
+      dimensionElectricCurrent
+      dimensionThermodynamicTemperature
+      dimensionAmountOfSubstance
+      dimensionLuminousIntensity
+      dynamicParameterPropertyCodes
+      example
+      isDynamic
+      isRequired
+      isWritable
+      maxExclusive
+      maxInclusive
+      methodOfMeasurement
+      minExclusive
+      minInclusive
+      pattern
+      physicalQuantity
+      predefinedValue
+      propertySet
+      propertyValueKind
+      symbol
+      # Non nullable by definition, returns nulls
+      # textFormat
+      units
+      activationDateUtc
+      code
+      creatorLanguageCode
+      countriesOfUse
+      countryOfOrigin
+      deActivationDateUtc
+      definition
+      deprecationExplanation
+      documentReference
+      name
+      replacedObjectCodes
+      replacingObjectCodes
+      revisionDateUtc
+      revisionNumber
+      status
+      subdivisionsOfUse
+      uid
+      versionDateUtc
+      versionNumber
+      visualRepresentationUri
+    }
+    childs {
+      id: namespaceUri
+      __typename
+    }
+    relations {
+      id: relatedClassificationUri
+      __typename
+      name: relatedClassificationName
+      type: relationType
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests~=2.22.0
+PyYAML~=5.3.1


### PR DESCRIPTION
Added different Python scripts for crawling and exporting bSDD data:

- Added GraphQL queries and python API bssd_graphql_api.py for crawling the bSDD GraphQL API and returning JSON responses.
- Export bSDD data to CSVs: Added a new Python script bsdd2csv.py for crawling the bSDD GraphQL API and exporting everything in CSV files.
- Added JSON API export: Added bsdd2json.py script for crawling the bsDD GraphQL API and exporting everything in CSV files.
- Added CLI utility for exporting bSDD data by invoking the graphql queries